### PR TITLE
PLAT-1306 Avoid lambda based implementation of a task action

### DIFF
--- a/src/main/java/com/softicar/gradle/AbstractSofticarProjectPlugin.java
+++ b/src/main/java/com/softicar/gradle/AbstractSofticarProjectPlugin.java
@@ -1,7 +1,9 @@
 package com.softicar.gradle;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskProvider;
@@ -18,7 +20,19 @@ public abstract class AbstractSofticarProjectPlugin implements Plugin<Project> {
 
 	protected void applyManifest(TaskProvider<Jar> jarTaskProvider) {
 
-		jarTaskProvider.get().doFirst(task -> {
+		jarTaskProvider.get().doFirst(new ApplyManifestAction());
+	}
+
+	protected JavaPluginExtension JavaPluginExtension(Project project) {
+
+		return project.getExtensions().getByType(JavaPluginExtension.class);
+	}
+
+	private class ApplyManifestAction implements Action<Task> {
+
+		@Override
+		public void execute(Task task) {
+
 			Jar jarTask = (Jar) task;
 			Attributes attributes = jarTask.getManifest().getAttributes();
 			attributes.put("Implementation-Title", jarTask.getProject().getName());
@@ -26,11 +40,6 @@ public abstract class AbstractSofticarProjectPlugin implements Plugin<Project> {
 			attributes.put("Built-By", System.getProperty("user.name"));
 			attributes.put("Built-JDK", System.getProperty("java.version"));
 			attributes.put("Built-Gradle", jarTask.getProject().getGradle().getGradleVersion());
-		});
-	}
-
-	protected JavaPluginExtension JavaPluginExtension(Project project) {
-
-		return project.getExtensions().getByType(JavaPluginExtension.class);
+		}
 	}
 }


### PR DESCRIPTION
According to the [Gradle documentation](https://docs.gradle.org/7.3/userguide/validation_problems.html#implementation_unknown), lambdas must no longer be used to define task actions because Gradle cannot track their executions.
